### PR TITLE
Fix crash when nist.gov requires HTTPS

### DIFF
--- a/cve-parser.go
+++ b/cve-parser.go
@@ -156,7 +156,7 @@ func main() {
 
 		go func(cve string) {
 
-			doc, err := goquery.NewDocument("http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-" + cve)
+			doc, err := goquery.NewDocument("https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-" + cve)
 			if err != nil {
 				log.Fatal(err.Error())
 			}


### PR DESCRIPTION
"An existing connection was forcibly closed by the remote host."
